### PR TITLE
Provide project-generation Spring Boot options 2.5.7 and 2.6.1

### DIFF
--- a/scribe-configurations/scribe-app/src/main/resources/application.yml
+++ b/scribe-configurations/scribe-app/src/main/resources/application.yml
@@ -83,6 +83,6 @@ initializr:
       default: true
       action: /starter.zip
   bootVersions:
-    - name: 2.5.6
-      id: 2.5.6
+    - name: 2.5.7
+      id: 2.5.7
       default: true

--- a/scribe-configurations/scribe-app/src/main/resources/application.yml
+++ b/scribe-configurations/scribe-app/src/main/resources/application.yml
@@ -86,3 +86,5 @@ initializr:
     - name: 2.5.7
       id: 2.5.7
       default: true
+    - name: 2.6.1
+      id: 2.6.1


### PR DESCRIPTION
- `2.5.7` is the new default Spring Boot version for generated projects
- `2.6.1` is also available (with parameter `bootVersion=2.6.1`) for testing purposes

*NOTE* generated projects currently fail with Spring Boot 2.6.1 !!