### PR TITLE
Cleaning up lombok model and dependency management

### DIFF
--- a/scribe-drivers/scribe-driver-web/src/main/java/eu/xenit/contentcloud/scribe/drivers/rest/ScribeProjectRequestToDescriptionConverter.java
+++ b/scribe-drivers/scribe-driver-web/src/main/java/eu/xenit/contentcloud/scribe/drivers/rest/ScribeProjectRequestToDescriptionConverter.java
@@ -39,12 +39,7 @@ public class ScribeProjectRequestToDescriptionConverter
                     description.setPackageName(description.getGroupId() + "." + asValidComponent(changeset.getProject()));
                 });
 
-        if (request.isLombok()) {
-            Dependency lombok = Optional.ofNullable(metadata.getDependencies().get("lombok")).orElseThrow();
-            description.addDependency(lombok.getId(), MetadataBuildItemMapper.toDependency(lombok));
-            description.useLombok(true);
-        }
-
+        description.useLombok(request.isLombok());
 
         return description;
     }

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/build/ContentCloudBuildProjectGenerationConfiguration.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/build/ContentCloudBuildProjectGenerationConfiguration.java
@@ -1,5 +1,6 @@
 package eu.xenit.contentcloud.scribe.generator.build;
 
+import eu.xenit.contentcloud.scribe.generator.ScribeProjectDescription;
 import eu.xenit.contentcloud.scribe.generator.build.gradle.ContentCloudAnnotationsStarterGradleBuildCustomizer;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
@@ -7,10 +8,14 @@ import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.metadata.InitializrMetadata;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 
+@RequiredArgsConstructor
 @ProjectGenerationConfiguration
 public class ContentCloudBuildProjectGenerationConfiguration {
+
+    private final ScribeProjectDescription projectDescription;
 
     @Bean
     public ContentCloudStarterBuildCustomizer contentCloudStarterBuildCustomizer(InitializrMetadata metadata) {
@@ -22,6 +27,11 @@ public class ContentCloudBuildProjectGenerationConfiguration {
     public ContentCloudAnnotationsStarterGradleBuildCustomizer contentCloudAnnotationsStarterGradleBuildCustomizer(
             InitializrMetadata metadata) {
         return new ContentCloudAnnotationsStarterGradleBuildCustomizer(metadata);
+    }
+
+    @Bean
+    public LombokDependencyBuildCustomizer lombokDependencyBuildCustomizer(InitializrMetadata metadata) {
+        return new LombokDependencyBuildCustomizer(this.projectDescription, metadata);
     }
 
 }

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/build/LombokDependencyBuildCustomizer.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/build/LombokDependencyBuildCustomizer.java
@@ -1,0 +1,24 @@
+package eu.xenit.contentcloud.scribe.generator.build;
+
+import eu.xenit.contentcloud.scribe.generator.ScribeProjectDescription;
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.initializr.metadata.support.MetadataBuildItemMapper;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LombokDependencyBuildCustomizer implements BuildCustomizer<Build> {
+
+    private final ScribeProjectDescription description;
+    private final InitializrMetadata metadata;
+
+    @Override
+    public void customize(Build build) {
+        if (this.description.useLombok()) {
+            var lombok = Optional.ofNullable(metadata.getDependencies().get("lombok")).orElseThrow();
+            build.dependencies().add(lombok.getId(), MetadataBuildItemMapper.toDependency(lombok));
+        }
+    }
+}

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/entitymodel/EntityModelSourceCodeProjectContributor.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/entitymodel/EntityModelSourceCodeProjectContributor.java
@@ -3,10 +3,14 @@ package eu.xenit.contentcloud.scribe.generator.entitymodel;
 import eu.xenit.contentcloud.scribe.changeset.Entity;
 import eu.xenit.contentcloud.scribe.generator.ScribeProjectDescription;
 import eu.xenit.contentcloud.scribe.generator.service.DefaultPackageStructure;
+import eu.xenit.contentcloud.scribe.generator.service.PackageStructure;
 import eu.xenit.contentcloud.scribe.generator.source.java.JavaSourceGenerator;
 import eu.xenit.contentcloud.scribe.generator.source.SourceGenerator;
+import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.language.SourceStructure;
+import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.project.contributor.ProjectContributor;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
@@ -25,25 +29,37 @@ public class EntityModelSourceCodeProjectContributor implements ProjectContribut
 
     private final EntityModel entityModel;
 
-
     @Override
     public void contribute(Path projectRoot) throws IOException {
-        SourceStructure mainSource = this.description.getBuildSystem().getMainSource(projectRoot, this.description.getLanguage());
-        DefaultPackageStructure packages = new DefaultPackageStructure(this.description);
+        Language language = this.description.getLanguage();
 
-        SourceGenerator sourceGen = new JavaSourceGenerator(packages, this.description.useLombok());
+        PackageStructure packages = new DefaultPackageStructure(this.description);
+        SourceGenerator sourceGen = createSourceGenerator(language, packages);
+        SourceStructure mainSource = this.description.getBuildSystem().getMainSource(projectRoot, language);
 
         for (Entity entity : this.entityModel.entities()) {
             contributeEntity(mainSource, sourceGen, entity);
         }
     }
 
+    private JavaSourceGenerator createSourceGenerator(@NonNull Language language, @NonNull PackageStructure packages) {
+        if (language instanceof JavaLanguage) {
+            return new JavaSourceGenerator((JavaLanguage) language, packages);
+        }
+
+        throw new UnsupportedOperationException(String.format("Language '%s' is not supported", language));
+    }
+
     private void contributeEntity(SourceStructure mainSource,
-                                  SourceGenerator sourceGenerator,
-                                  Entity entity)
+            SourceGenerator sourceGenerator,
+            Entity entity)
             throws IOException {
 
         var jpaEntity = sourceGenerator.createJpaEntity(entity.getClassName());
+        jpaEntity.lombokTypeAnnotations(lombok -> lombok
+                .useGetter(this.description.useLombok())
+                .useSetter(this.description.useLombok())
+                .useNoArgsConstructor(this.description.useLombok()));
 
         entity.getAttributes().forEach(attribute -> {
             Type resolvedAttributeType = this.resolveAttributeType(attribute.getType());

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/JavaBean.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/JavaBean.java
@@ -3,6 +3,7 @@ package eu.xenit.contentcloud.scribe.generator.source;
 import eu.xenit.contentcloud.bard.TypeName;
 
 import java.lang.reflect.Type;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public interface JavaBean extends TypeBuilder {
@@ -14,5 +15,9 @@ public interface JavaBean extends TypeBuilder {
     }
 
     Stream<? extends JavaBeanProperty> fields();
+
+    JavaBean lombokTypeAnnotations(Consumer<LombokTypeAnnotationsCustomizer> lombok);
+
+    LombokTypeAnnotationsConfig lombok();
 }
 

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotations.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotations.java
@@ -1,0 +1,15 @@
+package eu.xenit.contentcloud.scribe.generator.source;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter @Setter
+@Accessors(fluent = true, chain = true)
+public class LombokTypeAnnotations implements LombokTypeAnnotationsConfig, LombokTypeAnnotationsCustomizer {
+
+    private boolean useGetter = false;
+    private boolean useSetter = false;
+    private boolean useNoArgsConstructor = false;
+
+}

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotationsConfig.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotationsConfig.java
@@ -1,0 +1,9 @@
+package eu.xenit.contentcloud.scribe.generator.source;
+
+public interface LombokTypeAnnotationsConfig {
+
+    boolean useGetter();
+    boolean useSetter();
+    boolean useNoArgsConstructor();
+
+}

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotationsCustomizer.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/LombokTypeAnnotationsCustomizer.java
@@ -1,0 +1,9 @@
+package eu.xenit.contentcloud.scribe.generator.source;
+
+public interface LombokTypeAnnotationsCustomizer {
+
+    LombokTypeAnnotationsCustomizer useGetter(boolean useLombok);
+    LombokTypeAnnotationsCustomizer useSetter(boolean useLombok);
+    LombokTypeAnnotationsCustomizer useNoArgsConstructor(boolean useLombok);
+
+}

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/java/JavaSourceGenerator.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/java/JavaSourceGenerator.java
@@ -5,6 +5,7 @@ import eu.xenit.contentcloud.bard.TypeSpec;
 import eu.xenit.contentcloud.scribe.generator.service.PackageStructure;
 import eu.xenit.contentcloud.scribe.generator.source.jpa.JpaEntity;
 import eu.xenit.contentcloud.scribe.generator.source.SourceGenerator;
+import io.spring.initializr.generator.language.java.JavaLanguage;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -12,14 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class JavaSourceGenerator implements SourceGenerator {
 
     @NonNull
-    private final PackageStructure packageStructure;
+    private final JavaLanguage language;
 
-    private final boolean useLombok;
+    @NonNull
+    private final PackageStructure packageStructure;
 
     @Override
     public JpaEntity createJpaEntity(String name) {
         return JpaEntity.withClassName(name)
-                .withGenerator(jpaEntity -> generateJavaSource(new JpaEntityTypeSpec(jpaEntity, useLombok).build())
+                .withGenerator(jpaEntity -> generateJavaSource(new JpaEntityTypeSpec(jpaEntity).build())
         );
     }
 

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/java/JpaEntityTypeSpec.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/java/JpaEntityTypeSpec.java
@@ -9,21 +9,17 @@ import eu.xenit.contentcloud.bard.TypeSpec;
 import eu.xenit.contentcloud.scribe.generator.source.jpa.JpaEntity;
 import eu.xenit.contentcloud.scribe.generator.source.jpa.JpaEntityField;
 import eu.xenit.contentcloud.scribe.generator.source.jpa.JpaEntityIdField;
-import lombok.NoArgsConstructor;
+import java.beans.Introspector;
+import javax.lang.model.element.Modifier;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
-
-import javax.lang.model.element.Modifier;
-import java.beans.Introspector;
 
 @RequiredArgsConstructor
 class JpaEntityTypeSpec {
 
     @NonNull
     private final JpaEntity jpaEntity;
-
-    private final boolean useLombok;
 
     public TypeSpec build() {
         var type = TypeSpec.classBuilder(jpaEntity.className())
@@ -32,8 +28,11 @@ class JpaEntityTypeSpec {
 
         this.addConstructor(type);
 
-        if (this.useLombok) {
+        if (this.jpaEntity.lombok().useGetter()) {
             type.addAnnotation(ClassName.get("lombok", "Getter"));
+        }
+
+        if (this.jpaEntity.lombok().useSetter()) {
             type.addAnnotation(ClassName.get("lombok", "Setter"));
         }
 
@@ -44,7 +43,7 @@ class JpaEntityTypeSpec {
     }
 
     private void addConstructor(TypeSpec.Builder type) {
-        if (this.useLombok) {
+        if (this.jpaEntity.lombok().useNoArgsConstructor()) {
             type.addAnnotation(ClassName.get("lombok", "NoArgsConstructor"));
         } else {
             type.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build());
@@ -64,8 +63,8 @@ class JpaEntityTypeSpec {
     }
 
     private void addSetter(JpaEntityField field, TypeSpec.Builder type, FieldSpec.Builder fieldSpec) {
-        if (this.useLombok) {
-            // is there a @Getter on class-level ?
+        if (this.jpaEntity.lombok().useSetter()) {
+            // there is a @Setter class annotation
         } else {
             MethodSpec setter = MethodSpec.methodBuilder("set" + StringUtils.capitalize(field.name()))
                     .addModifiers(Modifier.PUBLIC)
@@ -80,8 +79,8 @@ class JpaEntityTypeSpec {
     private void addGetter(JpaEntityField field, TypeSpec.Builder type, FieldSpec.Builder fieldSpec) {
         // using lombok ?
         boolean useLombok = false;
-        if (this.useLombok) {
-            // is there a @Getter on class-level ?
+        if (this.jpaEntity.lombok().useGetter()) {
+            // there is a @Getter class annotation
         } else {
             MethodSpec getter = MethodSpec.methodBuilder("get" + StringUtils.capitalize(field.name()))
                     .addModifiers(Modifier.PUBLIC)

--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/jpa/JpaEntity.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/source/jpa/JpaEntity.java
@@ -2,6 +2,9 @@ package eu.xenit.contentcloud.scribe.generator.source.jpa;
 
 import eu.xenit.contentcloud.bard.TypeName;
 import eu.xenit.contentcloud.scribe.generator.source.JavaBean;
+import eu.xenit.contentcloud.scribe.generator.source.LombokTypeAnnotations;
+import eu.xenit.contentcloud.scribe.generator.source.LombokTypeAnnotationsConfig;
+import eu.xenit.contentcloud.scribe.generator.source.LombokTypeAnnotationsCustomizer;
 import eu.xenit.contentcloud.scribe.generator.source.SourceFile;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,6 +73,8 @@ class JpaEntityImpl implements JpaEntity {
 
     private final List<JpaEntityField> fields = new ArrayList<>();
 
+    private final LombokTypeAnnotations lombok = new LombokTypeAnnotations();
+
     @Override
     public SourceFile generate() {
         return this.generator.createSourceFile(this);
@@ -91,4 +96,17 @@ class JpaEntityImpl implements JpaEntity {
     public Stream<JpaEntityField> fields() {
         return this.fields.stream();
     }
+
+    @Override
+    public JavaBean lombokTypeAnnotations(Consumer<LombokTypeAnnotationsCustomizer> customizer) {
+        customizer.accept(this.lombok);
+        return this;
+    }
+
+    @Override
+    public LombokTypeAnnotationsConfig lombok() {
+        return this.lombok;
+    }
+
+
 }

--- a/scribe-generator/src/test/java/eu/xenit/contentcloud/scribe/generator/build/LombokDependencyBuildCustomizerTest.java
+++ b/scribe-generator/src/test/java/eu/xenit/contentcloud/scribe/generator/build/LombokDependencyBuildCustomizerTest.java
@@ -1,0 +1,63 @@
+package eu.xenit.contentcloud.scribe.generator.build;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import eu.xenit.contentcloud.scribe.generator.ScribeProjectDescription;
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.initializr.metadata.support.MetadataBuildItemResolver;
+import org.junit.jupiter.api.Test;
+
+class LombokDependencyBuildCustomizerTest {
+
+    @Test
+    void lombokDependencyAdded_whenRequested() {
+        var lombok = Dependency.withId("lombok",  "org.projectlombok", "lombok", null, Dependency.SCOPE_ANNOTATION_PROCESSOR);
+        var metadata = InitializrMetadataTestBuilder.withDefaults()
+                .addDependencyGroup("group", lombok).build();
+
+        var description = new ScribeProjectDescription();
+        description.useLombok(true);
+        var build = createBuild(metadata);
+
+        assertThat(build.dependencies().ids()).doesNotContain("lombok");
+        new LombokDependencyBuildCustomizer(description, metadata).customize(build);
+        assertThat(build.dependencies().ids()).containsOnly("lombok");
+    }
+
+    @Test
+    void noLombokDependencyAdded_whenNotRequested() {
+        var lombok = Dependency.withId("lombok",  "org.projectlombok", "lombok", null, Dependency.SCOPE_ANNOTATION_PROCESSOR);
+        var metadata = InitializrMetadataTestBuilder.withDefaults()
+                .addDependencyGroup("group", lombok).build();
+
+        var description = new ScribeProjectDescription();
+        description.useLombok(false);
+        var build = createBuild(metadata);
+
+        new LombokDependencyBuildCustomizer(description, metadata).customize(build);
+        assertThat(build.dependencies().ids()).doesNotContain("lombok");
+    }
+
+    @Test
+    void throws_whenMetadataIsNotAvailable() {
+        var metadata = InitializrMetadataTestBuilder.withDefaults().build();
+
+        var description = new ScribeProjectDescription();
+        description.useLombok(true);
+
+        var build = createBuild(metadata);
+
+        assertThatThrownBy(() -> new LombokDependencyBuildCustomizer(description, metadata).customize(build));
+    }
+
+    private Build createBuild(InitializrMetadata metadata) {
+        return new GradleBuild(new MetadataBuildItemResolver(metadata, Version.parse("2.0.0.RELEASE")));
+    }
+
+}


### PR DESCRIPTION
I was trying to remove `JpaEntityTypeSpec`: it's another (wrong?) abstraction layer, we don't need.  What we do want is translate `JpaEntity` (the scribe model) into a `TypeSpec` (the bard/java-poet model).

To accomplish that, the lombok-modelling needs to move first to `JpaEntity`

This PR:
* moves lombok from `JavaSourceGenerator` into the `JpaEntity` model. This allows better control over wether we need to generate getters & setters or not, and mainly prepares the removal of `JpaEntityTypeSpec`.
* moves responsibility to manage the lombok dependency to a more appropriate `BuildCustomizer<Build>` (tangential related to the original goal)