### PR TITLE
Use 'fs' as default storage type for spring-content

### DIFF
--- a/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/spring/content/SpringContentProjectionGenerationConfiguration.java
+++ b/scribe-generator/src/main/java/eu/xenit/contentcloud/scribe/generator/spring/content/SpringContentProjectionGenerationConfiguration.java
@@ -1,0 +1,14 @@
+package eu.xenit.contentcloud.scribe.generator.spring.content;
+
+import eu.xenit.contentcloud.scribe.generator.properties.ApplicationPropertiesCustomizer;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@ProjectGenerationConfiguration
+public class SpringContentProjectionGenerationConfiguration {
+
+    @Bean
+    ApplicationPropertiesCustomizer springContentDefaultStorage() {
+        return properties -> properties.put("spring.content.storage.type.default", "fs");
+    }
+}

--- a/scribe-generator/src/main/resources/META-INF/spring.factories
+++ b/scribe-generator/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,5 @@ io.spring.initializr.generator.project.ProjectGenerationConfiguration=\
 eu.xenit.contentcloud.scribe.generator.service.ApiServiceGenerationConfiguration,\
 eu.xenit.contentcloud.scribe.generator.build.ContentCloudBuildProjectGenerationConfiguration,\
 eu.xenit.contentcloud.scribe.generator.spring.data.SpringDataProjectGenerationConfiguration,\
+eu.xenit.contentcloud.scribe.generator.spring.content.SpringContentProjectionGenerationConfiguration,\
 eu.xenit.contentcloud.scribe.generator.properties.ApplicationPropertiesProjectGenerationConfiguration


### PR DESCRIPTION
This PR adds the following settings to `application.yml`, so content-cloud applications run without specifying an AWS_REGION env variable:

```
spring
  content:
    storage:
      type:
        default: fs
```