### PR TITLE
Bump io.spring.initializr from 0.11.0 to 0.12.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,4 @@ group=eu.xenit.contentcloud.scribe
 
 lombokPluginVersion=6.1.0
 springBootVersion=2.6.6
-springInitializrVersion=0.11.0
 bardVersion=0.1.0

--- a/scribe-dependencies/build.gradle
+++ b/scribe-dependencies/build.gradle
@@ -23,13 +23,6 @@ dependencies {
     constraints {
         api "eu.xenit.contentcloud.bard:bard:${bardVersion}"
 
-        api ('org.assertj:assertj-core') {
-            version {
-                strictly '3.19.0'
-            }
-            because '3.21 results in a NoSuchMethodException with initializr:0.11.0'
-        }
-
         api project(':scribe-generator')
         api project(':scribe-drivers:scribe-driver-web')
         api project(':scribe-configurations:scribe-app')

--- a/scribe-dependencies/build.gradle
+++ b/scribe-dependencies/build.gradle
@@ -18,7 +18,7 @@ javaPlatform {
 
 dependencies {
     api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
-    api platform("io.spring.initializr:initializr-bom:${springInitializrVersion}")
+    api platform("io.spring.initializr:initializr-bom:0.12.0")
 
     constraints {
         api "eu.xenit.contentcloud.bard:bard:${bardVersion}"

--- a/scribe-generator/build.gradle
+++ b/scribe-generator/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation 'eu.xenit.contentcloud.bard:bard:0.1.0-SNAPSHOT'
     implementation 'org.slf4j:slf4j-api'
 
-    testImplementation enforcedPlatform(project(":scribe-dependencies"))
     testImplementation project(':scribe-infrastructure')
     testImplementation 'org.springframework.hateoas:spring-hateoas'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
Initizlir updated to 0.12.0, which allowes to clean up build cruft related to the pinned assertj-core dependency constraints.